### PR TITLE
Do not sync before "PRUSA uvlo" during EEPROM recovery

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -10964,7 +10964,6 @@ void restore_print_from_eeprom() {
   // Set a position in the file.
   sprintf_P(cmd, PSTR("M26 S%lu"), position);
   enquecommand(cmd);
-  enquecommand_P(PSTR("G4 S0")); 
   enquecommand_P(PSTR("PRUSA uvlo"));
 }
 #endif //UVLO_SUPPORT


### PR DESCRIPTION
While the extruder is unparking after a PowerPanic recovery you can stop
the print via the LCD. This stops the print during "G4", before "PRUSA
uvlo" is scheduled. Without this, the following powerup will try to
resume a print which was aborted.

Let the PP resume parse "PRUSA uvlo" immediately, clearing the uvlo flag
as soon as stop is available. There's no need to sync anyway.