### PR TITLE
Drop min nozzle temperature to 5 degrees

### DIFF
--- a/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
@@ -280,7 +280,7 @@
  *------------------------------------*/
 
 // Mintemps
-#define HEATER_0_MINTEMP 15
+#define HEATER_0_MINTEMP 5
 #define HEATER_1_MINTEMP 5
 #define HEATER_2_MINTEMP 5
 #define HEATER_MINTEMP_DELAY 15000                // [ms] ! if changed, check maximal allowed value @ ShortTimer

--- a/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3S-EINSy10a-E3Dv6full.h
@@ -282,7 +282,7 @@
  *------------------------------------*/
 
 // Mintemps
-#define HEATER_0_MINTEMP 15
+#define HEATER_0_MINTEMP 5
 #define HEATER_1_MINTEMP 5
 #define HEATER_2_MINTEMP 5
 #define HEATER_MINTEMP_DELAY 15000                // [ms] ! if changed, check maximal allowed value @ ShortTimer


### PR DESCRIPTION
This drops the minimum nozzle temperature from 15 degrees celsius to 5 degrees celsius for both the MK3 and MK3S. The 15
degree lower limit was a remnant of the MK2 board which could not sense lower than 15 degrees celsius. The MK3 (and MK3S) can
both go down to 0 degrees, so 5 degrees is a relatively arbitrary amount of safety margin over 0. This value does not come
from the thermistor itself, but from the firmware which has been implemented to not read below 0.